### PR TITLE
Fix: filter system tiddlers from backlinks

### DIFF
--- a/plugins/rmnvsl/krystal/references.tid
+++ b/plugins/rmnvsl/krystal/references.tid
@@ -1,10 +1,10 @@
 title: $:/plugins/rmnvsl/krystal/references
 tags: $:/tags/ViewTemplate
 
-<$list filter="[!is[system]all[current]backlinks[]sort[title]] -[is[current]] +[limit[1]]" variable=none>
+<$list filter="[all[current]backlinks[]!is[system]sort[title]] -[is[current]] +[limit[1]]" variable=none>
 <ul class="krystal-references">
 <li class="krystal-references__title"><strong><$transclude tiddler="$:/plugins/rmnvsl/krystal/referenceshere" field="text" mode="inline" /></strong></li>
-<$list filter="[!is[system]all[current]backlinks[]sort[title]] -[is[current]]">
+<$list filter="[all[current]backlinks[]!is[system]sort[title]] -[is[current]]">
 <li class="krystal-references__reference">
 <$link>
 <b><$view field="title" /></b>


### PR DESCRIPTION
Hello! Thanks for your wonderful plugin / theme for TiddlyWiki. I noticed an issue with the References section pulling in system tiddlers ($:/DefaultTiddlers was being pulled in as a backlink).

The issue is that `!is[system]` was not filtering out system tiddlers from the references section - moving it after `backlinks[]` correctly filters any system tiddlers out of the references section.